### PR TITLE
allow storing svg in external file

### DIFF
--- a/board/main.js
+++ b/board/main.js
@@ -1206,7 +1206,7 @@ function initPaint(svgId, conf = null) {
       let textarea = document.createElement("textarea");
       let {x,y,width,height} = svg.getBBox();
       textarea.value = svg.outerHTML.replace('<svg id="svg">',
-      `<svg id="svg" viewbox="${x-10},${y-10},${width+20},${height+20}" style="height:${height+20}">`);
+        `<svg id="svg" xmlns="http://www.w3.org/2000/svg" viewbox="${x - 10},${y - 10},${width + 20},${height + 20}" style="height:${height + 20}">`);
       document.querySelector("#images").append(textarea);
       window?.drawAPI.unstable.setTextContent(textarea.value+'  ');
       document.querySelector('#text-'+s)?.onclick()

--- a/board/webview.js
+++ b/board/webview.js
@@ -84,6 +84,9 @@ const drawAPI = {
       if (content.startsWith('<svg id="svg"')) {
         drawAPI.unstable.setSVGContent(content)
       }
+      else if (match = /!\[.*\]\((.*\.svg)\)/.exec(content)) {
+        drawAPI.unstable.readSVGContent(match[1])
+      }
     },
     custom(content) {
       console.log(content);
@@ -115,6 +118,9 @@ window.addEventListener('message', event => {
     case 'custom':
       drawAPI.unstable.custom(message.content);
       break;
+    case 'readFile':
+      drawAPI.unstable.setSVGContent(message.content);
+      break;
   }
 });
 
@@ -145,6 +151,12 @@ document.querySelector('#text-change-nextline').onclick = function () {
         text,
         control,
         command: 'editCurrentLine',
+      })
+    }
+    drawAPI.unstable.readSVGContent = (file) => {
+      vscode.postMessage({
+        file,
+        command: 'readFile',
       })
     }
     vscode.postMessage({ command: 'requestCurrentLine' })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,45 @@
 {
 	"name": "vscode-markdown-draw",
-	"version": "0.1.0",
-	"lockfileVersion": 1,
+	"version": "0.1.4",
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "vscode-markdown-draw",
+			"version": "0.1.4",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"uuid": "^8.3.2"
+			},
+			"devDependencies": {
+				"@types/node": "^12.12.0",
+				"@types/vscode": "^1.47.0"
+			},
+			"engines": {
+				"vscode": "^1.47.0"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "12.19.4",
+			"resolved": "https://registry.npm.taobao.org/@types/node/download/@types/node-12.19.4.tgz?cache=0&sync_timestamp=1604951079891&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fnode%2Fdownload%2F%40types%2Fnode-12.19.4.tgz",
+			"integrity": "sha1-zfu2LibHQ17ZqrnJQTk8w1mOm0Y=",
+			"dev": true
+		},
+		"node_modules/@types/vscode": {
+			"version": "1.51.0",
+			"resolved": "https://registry.npm.taobao.org/@types/vscode/download/@types/vscode-1.51.0.tgz",
+			"integrity": "sha1-8uMk2DhduVAwsUVP0fBDYY4ICX0=",
+			"dev": true
+		},
+		"node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		}
+	},
 	"dependencies": {
 		"@types/node": {
 			"version": "12.19.4",
@@ -15,6 +52,11 @@
 			"resolved": "https://registry.npm.taobao.org/@types/vscode/download/@types/vscode-1.51.0.tgz",
 			"integrity": "sha1-8uMk2DhduVAwsUVP0fBDYY4ICX0=",
 			"dev": true
+		},
+		"uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -67,14 +67,21 @@
 						}
 					],
 					"description": "Add customized buttons. See README.md for details"
+				},
+				"markdown-draw.directory": {
+					"type": "string",
+					"default": "",
+					"description": "Save SVG to directory; write SVG inline if blank"
 				}
 			}
 		}
 	},
 	"scripts": {},
-	"dependencies": {},
+	"dependencies": {
+		"uuid": "^8.3.2"
+	},
 	"devDependencies": {
-		"@types/vscode": "^1.47.0",
-		"@types/node": "^12.12.0"
+		"@types/node": "^12.12.0",
+		"@types/vscode": "^1.47.0"
 	}
 }


### PR DESCRIPTION
These changes add a `directory` setting, which, when set, saves the svg content to a generated UUID filename in that directory and writes a markdown image link to the file (e.g., `![](/path/to/directory/<UUID>.svg)`). When set to a blank string (the default), the previous behavior of saving the svg content inline remains.

This helps declutter the markdown source and makes it easier to share images across documents.

Really cool project, by the way :slightly_smiling_face:  